### PR TITLE
The "List of HTML" link is broken.

### DIFF
--- a/slowparse/spec/errors.base.html
+++ b/slowparse/spec/errors.base.html
@@ -37,7 +37,7 @@
   <p>If you just want a <code>&lt;</code> to appear on your Web
     page, try using <code>&amp;lt;</code> instead.</p>
     
-  <p>Or, see a <a href="http://joshduck.com/periodic-table.html">list of
+  <p>Or, see a <a href="http://www.stresslessweb.com/wp-content/uploads/2010/12/PeriodicTableOfTheElements-JoshDuck1.png">list of
     HTML5 tags</a>.</p>
 </div>
 <div class="error-msg UNTERMINATED_ATTR_VALUE">


### PR DESCRIPTION
The link is no longer available. Thus, is can be replace with http://www.stresslessweb.com/wp-content/uploads/2010/12/PeriodicTableOfTheElements-JoshDuck1.png
